### PR TITLE
Fix error in ClinicalTrialCoordinatingCenterName 

### DIFF
--- a/fs2dicom/templates/fs-aseg.json
+++ b/fs2dicom/templates/fs-aseg.json
@@ -3,7 +3,7 @@
   "ContentCreatorName": "FreeSurfer 6.0",
   "ClinicalTrialSeriesID": "Session1",
   "ClinicalTrialTimePointID": "1",
-  "ClinicalTrialCoordinatingCenterName": "",
+  "ClinicalTrialCoordinatingCenterName": " ",
   "SeriesDescription": "Segmentation",
   "SeriesNumber": "300",
   "InstanceNumber": "1",


### PR DESCRIPTION
Without this space, the following error still occurs when running `dciodvfy aseg-seg.dcm`:
```
Error - Missing attribute Type 2 Required Element=<ClinicalTrialCoordinatingCenterName> Module=<ClinicalTrialSeries>
```